### PR TITLE
Errorf and group change

### DIFF
--- a/errorf.go
+++ b/errorf.go
@@ -6,9 +6,17 @@ import (
 
 type Errorf string
 
-// Error is fullfilling the error interface only because it's much nicer to
-// use it with the Is method.
-func (Errorf) Error() string { panic("Errorf is not an error you should return") }
+type isableErrorf struct {
+	err Errorf
+}
+
+func (e isableErrorf) Error() string {
+	panic("not an error you should return. use it with errors.Is")
+}
+
+func (e Errorf) CheckIs() error {
+	return isableErrorf{e}
+}
 
 type formattedError struct {
 	origErr Errorf
@@ -17,9 +25,10 @@ type formattedError struct {
 
 func (e formattedError) Is(err error) bool {
 
-	if errf, ok := err.(Errorf); ok {
-		return e.origErr == errf
+	if isErrf, ok := err.(isableErrorf); ok {
+		return e.origErr == isErrf.err
 	}
+
 	errf, ok := err.(formattedError)
 	if !ok {
 		return false

--- a/errorf_test.go
+++ b/errorf_test.go
@@ -7,10 +7,8 @@ import (
 )
 
 func TestErrorf(t *testing.T) {
-	err1 := Errorf("hello")
-
-	err := err1.Format()
 	t.Run("Errorf generates an error", func(t *testing.T) {
+		err := Errorf("hello").Format()
 		_, ok := any(err).(error)
 		assert.True(t, ok)
 	})
@@ -26,6 +24,8 @@ func TestErrorf(t *testing.T) {
 			err21 = errf2.Format("bar", 3)
 			err22 = errf2.Format("foo", 8, 9)
 		)
+
+		assert.ErrorIs(t, err1, errf1.CheckIs())
 
 		assert.False(t, err1.Is(err21))
 		assert.False(t, err1.Is(err22))

--- a/errorf_test.go
+++ b/errorf_test.go
@@ -13,6 +13,13 @@ func TestErrorf(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+	t.Run("errorf isable error panics", func(t *testing.T) {
+		assert.Panics(t, func() {
+			err := Errorf("bla").CheckIs()
+			err.Error()
+		})
+	})
+
 	t.Run("testing Is", func(t *testing.T) {
 		var (
 			errf1 = Errorf("err: %s")

--- a/group.go
+++ b/group.go
@@ -7,12 +7,16 @@ import (
 
 type Group []error
 
-func (g *Group) Add(err error) {
+func (g *Group) Add(errs ...error) {
 	// nil errors are ignored
-	if err == nil {
+	if len(errs) == 0 {
 		return
 	}
-	*g = append(*g, err)
+	for _, err := range errs {
+		if err != nil {
+			*g = append(*g, err)
+		}
+	}
 }
 
 func (g Group) Err() bool {

--- a/group_test.go
+++ b/group_test.go
@@ -29,6 +29,12 @@ func TestGroupInitWithMultipleErrors(t *testing.T) {
 		errors.New("b"),
 	}
 	assert.True(t, err.Err())
+	err = Group{}
+	err.Add(
+		errors.New("c"),
+		errors.New("d"),
+	)
+	assert.True(t, err.Err())
 }
 
 func TestGroupUnwrapping(t *testing.T) {

--- a/group_test.go
+++ b/group_test.go
@@ -37,6 +37,16 @@ func TestGroupInitWithMultipleErrors(t *testing.T) {
 	assert.True(t, err.Err())
 }
 
+func TestGroupAddingWithEmptyDoesntAdd(t *testing.T) {
+	var g Group
+	g.Add()
+	assert.False(t, g.Err())
+	g.Add(nil)
+	assert.False(t, g.Err())
+	g.Add(nil, nil)
+	assert.False(t, g.Err())
+}
+
 func TestGroupUnwrapping(t *testing.T) {
 	var (
 		err1 = errors.New("err1")


### PR DESCRIPTION
## Errorf
- removed the error interface
- there is a new method CheckIs which is supposed to be used with the error.Is

## Group
- added var argument for adding errors to group